### PR TITLE
Add light theme toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,22 +4,25 @@ import LandingPage from './pages/LandingPage'
 import NewLandingPage from './pages/NewLandingPage'
 import ChatShell from './pages/Chat'
 import { AuthContext, AuthStatus } from './hooks/useAuthState'
+import { ThemeProvider } from './hooks/useTheme'
 
 function App() {
   const [authState, setAuthState] = useState<AuthStatus>('guest')
 
   return (
-    <AuthContext.Provider value={{ status: authState, setStatus: setAuthState }}>
-      <Router>
-        <Routes>
-          {/* Use new landing page */}
-          <Route path="/" element={<NewLandingPage />} />
-          <Route path="/old" element={<LandingPage />} />
-          <Route path="/chat" element={<ChatShell />} />
-          <Route path="/discord" element={<Navigate to="https://discord.gg/SNRKrSh2wF" />} />
-        </Routes>
-      </Router>
-    </AuthContext.Provider>
+    <ThemeProvider>
+      <AuthContext.Provider value={{ status: authState, setStatus: setAuthState }}>
+        <Router>
+          <Routes>
+            {/* Use new landing page */}
+            <Route path="/" element={<NewLandingPage />} />
+            <Route path="/old" element={<LandingPage />} />
+            <Route path="/chat" element={<ChatShell />} />
+            <Route path="/discord" element={<Navigate to="https://discord.gg/SNRKrSh2wF" />} />
+          </Routes>
+        </Router>
+      </AuthContext.Provider>
+    </ThemeProvider>
   )
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import { useTheme } from '../hooks/useTheme'
 import RiskDisclosure from './RiskDisclosure'
 
 interface LayoutProps {
@@ -7,6 +8,7 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
+  const { theme, toggleTheme } = useTheme()
   return (
     <div className="min-h-screen flex flex-col">
       <header className="h-20 px-8 border-b border-[#262626] flex justify-between items-center">
@@ -82,6 +84,32 @@ export default function Layout({ children }: LayoutProps) {
               <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>
             </svg>
           </a>
+
+          <button
+            onClick={toggleTheme}
+            className="text-text-primary hover:text-accent transition-colors"
+            aria-label="Toggle theme"
+          >
+            {theme === 'dark' ? (
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 3.1A7.9 7.9 0 1 0 19.9 11 5 5 0 0 1 12 3.1z" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <circle cx="12" cy="12" r="5" />
+                <g stroke="currentColor" strokeWidth="2" fill="none">
+                  <line x1="12" y1="1" x2="12" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="23" />
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                  <line x1="1" y1="12" x2="3" y2="12" />
+                  <line x1="21" y1="12" x2="23" y2="12" />
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                </g>
+              </svg>
+            )}
+          </button>
         </nav>
       </header>
 

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+export type Theme = 'dark' | 'light'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'dark',
+  toggleTheme: () => {}
+})
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark')
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -2,6 +2,29 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Theme color variables */
+:root {
+  --color-base: #0d0d0d;
+  --color-card: #1a1a1a;
+  --color-border: #262626;
+  --color-accent: #38bdf8;
+  --color-accent-hover: #0ea5e9;
+  --color-danger: #f43f5e;
+  --color-text-primary: #e4e4e7;
+  --color-text-muted: #9ca3af;
+}
+
+[data-theme='light'] {
+  --color-base: #ffffff;
+  --color-card: #f9fafb;
+  --color-border: #d1d5db;
+  --color-accent: #0ea5e9;
+  --color-accent-hover: #0284c7;
+  --color-danger: #dc2626;
+  --color-text-primary: #1f2937;
+  --color-text-muted: #6b7280;
+}
+
 @layer base {
   body {
     @apply bg-background text-text font-sans;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -8,17 +8,17 @@ export default {
   theme: {
     extend: {
       colors: {
-        base: '#0D0D0D',
-        card: '#1A1A1A',
-        border: '#262626',
-        accent: '#38BDF8',
-        'accent-hover': '#0EA5E9',
-        danger: '#F43F5E',
-        'text-primary': '#E4E4E7',
-        'text-muted': '#9CA3AF',
+        base: 'var(--color-base)',
+        card: 'var(--color-card)',
+        border: 'var(--color-border)',
+        accent: 'var(--color-accent)',
+        'accent-hover': 'var(--color-accent-hover)',
+        danger: 'var(--color-danger)',
+        'text-primary': 'var(--color-text-primary)',
+        'text-muted': 'var(--color-text-muted)',
         // Keep old colors for backward compatibility
-        background: '#0D0D0D',
-        text: '#E4E4E7',
+        background: 'var(--color-base)',
+        text: 'var(--color-text-primary)',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add color variables for light/dark themes
- support CSS variable colors in Tailwind config
- introduce `useTheme` hook and `ThemeProvider`
- wrap app with `ThemeProvider`
- add theme toggle button in the layout header

## Testing
- `npm run typecheck` *(fails: JSX type errors)*
- `npm run build` *(fails: vite not found)*