### PR TITLE
Remove theme switcher

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { useTheme } from '../hooks/useTheme'
 import RiskDisclosure from './RiskDisclosure'
 
 interface LayoutProps {
@@ -8,7 +7,6 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const { theme, toggleTheme } = useTheme()
   return (
     <div className="min-h-screen flex flex-col">
       <header className="h-20 px-8 border-b border-[#262626] flex justify-between items-center">
@@ -85,31 +83,6 @@ export default function Layout({ children }: LayoutProps) {
             </svg>
           </a>
 
-          <button
-            onClick={toggleTheme}
-            className="text-text-primary hover:text-accent transition-colors"
-            aria-label="Toggle theme"
-          >
-            {theme === 'dark' ? (
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 3.1A7.9 7.9 0 1 0 19.9 11 5 5 0 0 1 12 3.1z" />
-              </svg>
-            ) : (
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <circle cx="12" cy="12" r="5" />
-                <g stroke="currentColor" strokeWidth="2" fill="none">
-                  <line x1="12" y1="1" x2="12" y2="3" />
-                  <line x1="12" y1="21" x2="12" y2="23" />
-                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-                  <line x1="1" y1="12" x2="3" y2="12" />
-                  <line x1="21" y1="12" x2="23" y2="12" />
-                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-                </g>
-              </svg>
-            )}
-          </button>
         </nav>
       </header>
 

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,30 +1,22 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { createContext, useContext, useEffect, ReactNode } from 'react'
 
-export type Theme = 'dark' | 'light'
+export type Theme = 'light'
 
 interface ThemeContextType {
   theme: Theme
-  toggleTheme: () => void
 }
 
 const ThemeContext = createContext<ThemeContextType>({
-  theme: 'dark',
-  toggleTheme: () => {}
+  theme: 'light'
 })
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('dark')
-
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme)
-  }, [theme])
-
-  const toggleTheme = () => {
-    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
-  }
+    document.documentElement.setAttribute('data-theme', 'light')
+  }, [])
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme: 'light' }}>
       {children}
     </ThemeContext.Provider>
   )


### PR DESCRIPTION
## Summary
- remove theme toggle logic
- default the theme to light mode

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run typecheck` *(fails: missing modules)*